### PR TITLE
chore(package): update devDependency @types/node to v12.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -703,9 +703,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.18.tgz",
-      "integrity": "sha512-lywCnJQRSsu0kitHQ5nkb7Ay/ScdJPQjhWRtuf+G1DmNKJnPcdVyP0pYvdiDFKjzReC6NLWLgSyimno3kKfIig==",
+      "version": "12.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
+      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1419,7 +1419,7 @@
     },
     "doctrine": {
       "version": "0.7.2",
-      "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
@@ -7649,7 +7649,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/chai": "4.2.1",
     "@types/chai-as-promised": "7.1.2",
     "@types/mocha": "5.2.7",
-    "@types/node": "9.6.18",
+    "@types/node": "12.7.4",
     "@types/sinon": "7.0.13",
     "@types/sinon-chai": "3.2.3",
     "chai": "4.2.0",

--- a/src/process.ts
+++ b/src/process.ts
@@ -27,8 +27,8 @@ export function wrapGitProcessSync(args: string[], cwd: string): string {
   return child.stdout.toString();
 }
 
-function getErrorWithCode(code: number, message: string) {
-  type ErrorWithCode = Error & { code: number };
+function getErrorWithCode(code: number | null, message: string) {
+  type ErrorWithCode = Error & { code: number | null };
   const err = new Error(message) as ErrorWithCode;
   err.code = code;
   return err;


### PR DESCRIPTION
Fixes CI error by bumping version of `@types/node`.